### PR TITLE
Update the Neovim information

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ From the root directory of this project, run `code .` Then in VS Code
 
 ## Running in Nvim
 
-In your init.lua past the following into the config
 Place a file like this into your ./nvim/lua/plugins/zura.lua:
 
 ```lua
@@ -62,3 +61,5 @@ return {
   end,
 }
 ```
+
+Now, place the [`zura.vim`](./zura.vim) file into your `./nvim/syntax/` directory.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Zura Lsp and syntax highliter
 
 NOTE: This is heavily based on [lsp-sample from vscode-extension-samples][sample] with the goal of removing example-specific code to ease starting a new Language Server.
-NOTE: This was also my version of Jeffrey Chupp tutorial series https://www.youtube.com/watch?v=Xo5VXTRoL6Q&list=PLq5tGLDKHlW9XKRj5-plHdvbkT5AOdM7-
+NOTE: This was also my version of Jeffrey Chupp tutorial series <https://www.youtube.com/watch?v=Xo5VXTRoL6Q&list=PLq5tGLDKHlW9XKRj5-plHdvbkT5AOdM7->
 
 ## Getting Started
 
@@ -9,6 +9,7 @@ NOTE: This was also my version of Jeffrey Chupp tutorial series https://www.yout
 2. Run `npm install` from the repo root.
 
 ## Running in Vscode
+
 From the root directory of this project, run `code .` Then in VS Code
 
 1. Build the extension (both client and server) with `⌘+shift+B` (or `ctrl+shift+B` on windows)
@@ -21,47 +22,43 @@ From the root directory of this project, run `code .` Then in VS Code
 
 [Debugging instructions can be found here][debug]
 
-
-
 [debug]: https://code.visualstudio.com/api/language-extensions/language-server-extension-guide#debugging-both-client-and-server
 [sample]: https://github.com/microsoft/vscode-extension-samples/tree/main/lsp-sample
 [publish]: https://code.visualstudio.com/api/working-with-extensions/publishing-extension
 [vsix]: https://code.visualstudio.com/api/working-with-extensions/publishing-extension#packaging-extensions
 
 ## Running in Nvim
+
 In your init.lua past the following into the config
+Place a file like this into your ./nvim/lua/plugins/zura.lua:
+
 ```lua
-vim.filetype.add {
-  extension = {
-    zu = "zura", -- Map .zu files to zura
-  },
-}
+return {
+  "neovim/nvim-lspconfig",
+  lazy = false,
+  priority = 1000,
+  config = function()
+    -- Filetype setup
+    vim.filetype.add({
+      extension = { zu = "zura" },
+      pattern = { [".*%.zu"] = "zura" },
+    })
 
-vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
-  pattern = { "*.zu" },
-  callback = function()
-    -- Ensure .zu files are recognized as zura
-    vim.bo.filetype = "zura"
+    -- LSP setup
+    local lspconfig = require("lspconfig")
+    local configs = require("lspconfig.configs")
 
-    -- Check if the LSP is already attached
-    local clients = vim.lsp.get_clients()
-    for _, client in ipairs(clients) do
-      if client.name == "Zura Lsp" and client.config.cmd[3] == vim.fn.expand "~/Projects/Zura-Lsp/server/src/server.ts" then
-        return
-      end
+    if not configs.zura_ls then
+      configs.zura_ls = {
+        default_config = {
+          cmd = { "/home/thedevconnor/Zura-Transpiled/release/zura", "-lsp" },
+          filetypes = { "zura" },
+          root_dir = lspconfig.util.root_pattern(".git", ".zura-root"),
+        },
+      }
     end
 
-    -- Start the custom LSP
-    vim.lsp.start {
-      name = "Zura Lsp",
-      cmd = {
-        "npx",
-        "ts-node",
-        vim.fn.expand "~/Projects/Zura-Lsp/server/src/server.ts",
-      },
-      root_dir = vim.fn.getcwd(), -- Optionally set a root directory
-    }
+    lspconfig.zura_ls.setup({})
   end,
-})
-
+}
 ```

--- a/zura.vim
+++ b/zura.vim
@@ -1,0 +1,46 @@
+" zura.vim - Enhanced Syntax highlighting for Zura with custom colors
+
+" Define Zura keywords
+syn keyword zuraKeyword const fn have auto loop if else return enum struct typename template
+syn keyword zuraType int float bool str char
+syn match zuraBuiltIn /@\w\+/
+syn keyword zuraConditional if else
+syn keyword zuraLoop loop
+syn keyword zuraStatement return
+syn keyword zuraModifier const
+
+" Highlight numbers (integers and floats)
+syn match zuraNumber /\<\d\+\(\.\d\+\)\?\([eE][+-]\d\+\)\?/
+
+" Highlight strings (single and double quotes)
+syn region zuraString start=+"+ skip=+\\"+ end=+"+ contains=zuraEscape
+syn region zuraString start=+'+ skip=+\\'+ end=+'+ contains=zuraEscape
+
+" Highlight comments (single-line and multi-line)
+syn match zuraComment "#.*$"
+
+" Highlight structs, enums, and function declarations
+syn match zuraStruct /\<\(struct\|enum\)\>/
+syn match zuraFunction /\<fn\>\s\+\w\+\ze\s*[(]/
+
+" Highlight operators
+syn match zuraOperator /[:=(){}\[\],;.+\-*/<>]/
+
+" Highlight variables (avoid matching keywords)
+syn match zuraVariable /\<[a-zA-Z_]\w*\>/ contains=zuraKeyword,zuraType
+
+" Custom colors for Zura syntax (Horizon-style palette)
+hi def zuraKeyword guifg=#E95678 gui=bold               " Keywords: Warm pink
+hi def zuraType guifg=#25B0BC gui=italic                " Types: Vibrant cyan
+hi def zuraBuiltIn guifg=#FAB795 gui=bold,italic        " Built-ins: Peachy orange
+hi def zuraConditional guifg=#FAB28E gui=bold           " Conditionals: Muted orange
+hi def zuraLoop guifg=#FAB28E gui=bold                  " Loops: Muted orange
+hi def zuraStatement guifg=#FFD580 gui=italic           " Statements: Light peach
+hi def zuraModifier guifg=#25B0BC gui=bold              " Modifiers: Vibrant cyan
+hi def zuraNumber guifg=#E95678                         " Numbers: Warm pink
+hi def zuraString guifg=#09F7A0                         " Strings: Soft green
+hi def zuraComment guifg=#6C6F93 gui=italic             " Comments: Muted grayish-blue
+hi def zuraOperator guifg=#E95678                       " Operators: Warm pink
+hi def zuraStruct guifg=#25B0BC gui=bold                " Structs: Vibrant cyan
+hi def zuraFunction guifg=#FFD580 gui=bold              " Functions: Light peach
+hi def zuraVariable guifg=#FAB                          " Variables: light pink


### PR DESCRIPTION
Technically, the [Neovim repo](https://github.com/TheDevConnor/Nvim-Zura-Highliter) is completely obsolete; however, this is probably a good thing. If this repo were renamed to "Zura client extension" then both VSCode _and_ Neovim users can use this one repo instead of looking for theirs.

# three reasons why yous hould pull

1. im cool :+1:
2. this will, as reasons stated above, reduce confusion
3. neovim go brr

### also satire by the way